### PR TITLE
edit:error-handling so that no warnings shows up when clicking on edit

### DIFF
--- a/frontend/src/components/CreateEventsDialog.jsx
+++ b/frontend/src/components/CreateEventsDialog.jsx
@@ -116,7 +116,7 @@ export function CreateEventsDialog({ fetchEvents,  open, onOpenChange }) {
     <Dialog open={open} onOpenChange={onOpenChange}>
       <form>
        
-        <DialogContent className="sm:max-w-[625px] bg-white">
+        <DialogContent className="sm:max-w-[625px] bg-white"  aria-describedby={undefined}>
           <DialogHeader>
             <DialogTitle>Create Event</DialogTitle>
           </DialogHeader>

--- a/frontend/src/components/CreateSalesDialog.jsx
+++ b/frontend/src/components/CreateSalesDialog.jsx
@@ -147,7 +147,7 @@ onOpenChange(false);
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <form >
-        <DialogContent className="sm:max-w-[625px] bg-white">
+        <DialogContent className="sm:max-w-[625px] bg-white"  aria-describedby={undefined}>
           <DialogHeader>
             <DialogTitle>Create listing</DialogTitle>
           </DialogHeader>

--- a/frontend/src/components/Dialog.jsx
+++ b/frontend/src/components/Dialog.jsx
@@ -19,7 +19,7 @@ export function DialogDemo() {
         <DialogTrigger asChild>
           <Button variant="outline">edit</Button>
         </DialogTrigger>
-        <DialogContent className="sm:max-w-[425px]">
+        <DialogContent className="sm:max-w-[425px]"  aria-describedby={undefined}>
           <DialogHeader>
             <DialogTitle>Edit profile</DialogTitle>
             <DialogDescription>

--- a/frontend/src/components/EditEventDialog.jsx
+++ b/frontend/src/components/EditEventDialog.jsx
@@ -6,7 +6,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
+  DialogDescription,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -135,9 +135,9 @@ export function EditEventsDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={onOpenChange} >
       <form>
-        <DialogContent className="sm:max-w-[625px] bg-white">
+        <DialogContent className="sm:max-w-[625px] bg-white" aria-describedby={undefined}>
           <DialogHeader>
             <DialogTitle>Edit Event</DialogTitle>
           </DialogHeader>

--- a/frontend/src/components/EditSalesDialog.jsx
+++ b/frontend/src/components/EditSalesDialog.jsx
@@ -137,7 +137,7 @@ export function EditSalesDialog({ open, onOpenChange, defaultValues, fetchSales 
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[625px] bg-white">
+      <DialogContent className="sm:max-w-[625px] bg-white"  aria-describedby={undefined}>
         <DialogHeader>
           <DialogTitle>Edit Listing</DialogTitle>
         </DialogHeader>


### PR DESCRIPTION
Cleared the warning issues when clicking on the edit feature for both events and sales listings.